### PR TITLE
Chaining method and create reference from definition

### DIFF
--- a/src/InstanceDefinition.php
+++ b/src/InstanceDefinition.php
@@ -46,16 +46,19 @@ class InstanceDefinition extends NamedDefinition implements InstanceDefinitionIn
     public function addConstructorArgument($argument)
     {
         $this->constructorArguments[] = $argument;
+        return $this;
     }
 
     public function addPropertyAssignment(PropertyAssignmentInterface $propertyAssignment)
     {
         $this->propertyAssignments[] = $propertyAssignment;
+        return $this;
     }
 
     public function addMethodCall(MethodCallInterface $methodCall)
     {
         $this->methodCalls[] = $methodCall;
+        return $this;
     }
 
     /**

--- a/src/NamedDefinition.php
+++ b/src/NamedDefinition.php
@@ -23,4 +23,9 @@ abstract class NamedDefinition implements DefinitionInterface
     {
         return $this->identifier;
     }
+
+    public function createReference()
+    {
+        return new Reference($this->getIdentifier());
+    }
 }


### PR DESCRIPTION
Add some syntaxic sugar to permit : 

```
<?php
$fooInstance = new \Assembly\InstanceDefinition('fooInstance', 'foo');
$xmlClient
    ->addConstructorArgument(2)
    ->addPropertyAssignment(new \Assembly\PropertyAssignment('property', 'value'))
    ->addMethodCall(new \Assembly\MethodCall('method', ['argument']))
;

$barInstance = new \Assembly\InstanceDefinition('barInstace', 'bar');
$barInstance
    ->addConstructorArgument($fooInstance->createReference())
    ->addConstructorArgument('argument')
;
```
