### PR TITLE
Default argument for FactoryCall

### DIFF
--- a/src/FactoryCallDefinition.php
+++ b/src/FactoryCallDefinition.php
@@ -20,7 +20,7 @@ class FactoryCallDefinition extends NamedDefinition implements FactoryCallDefini
     /**
      * @var array
      */
-    private $arguments;
+    private $arguments = [];
 
     /**
      * @param string $identifier


### PR DESCRIPTION
Making the default value for FactoryCallDefinition->getArguments an empty array rather than null.
