### PR TITLE
Fix FactoryCallDefinitionInterface::$arguments not being used

### DIFF
--- a/src/Container/Container.php
+++ b/src/Container/Container.php
@@ -108,12 +108,14 @@ class Container implements ContainerInterface
             case $definition instanceof FactoryCallDefinitionInterface:
                 $factory = $definition->getFactory();
                 $methodName = $definition->getMethodName();
+                $arguments = (array) $definition->getArguments();
 
                 if (is_string($factory)) {
-                    return $factory::$methodName($requestedId);
+                    return call_user_func_array($factory. '::' .$methodName, $arguments);
                 } elseif ($factory instanceof ReferenceInterface) {
                     $factory = $this->get($factory->getTarget());
-                    return $factory->$methodName($requestedId);
+
+                    return call_user_func_array([$factory, $methodName], $arguments);
                 }
                 throw new InvalidDefinition(sprintf('Definition "%s" does not return a valid factory'));
             default:

--- a/src/Container/Container.php
+++ b/src/Container/Container.php
@@ -71,7 +71,6 @@ class Container implements ContainerInterface
      * Resolve a definition and return the resulting value.
      *
      * @param DefinitionInterface $definition
-     * @param string $requestedId
      * @return mixed
      * @throws UnsupportedDefinition
      * @throws EntryNotFound A dependency was not found.

--- a/src/Container/Container.php
+++ b/src/Container/Container.php
@@ -47,7 +47,7 @@ class Container implements ContainerInterface
             throw EntryNotFound::fromId($id);
         }
 
-        $this->entries[$id] = $this->resolveDefinition($this->definitions[$id], $id);
+        $this->entries[$id] = $this->resolveDefinition($this->definitions[$id]);
 
         return $this->entries[$id];
     }
@@ -76,7 +76,7 @@ class Container implements ContainerInterface
      * @throws UnsupportedDefinition
      * @throws EntryNotFound A dependency was not found.
      */
-    private function resolveDefinition(DefinitionInterface $definition, $requestedId)
+    private function resolveDefinition(DefinitionInterface $definition)
     {
         switch (true) {
             case $definition instanceof ParameterDefinitionInterface:
@@ -114,7 +114,6 @@ class Container implements ContainerInterface
                     return call_user_func_array($factory. '::' .$methodName, $arguments);
                 } elseif ($factory instanceof ReferenceInterface) {
                     $factory = $this->get($factory->getTarget());
-
                     return call_user_func_array([$factory, $methodName], $arguments);
                 }
                 throw new InvalidDefinition(sprintf('Definition "%s" does not return a valid factory'));

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -189,16 +189,16 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
     /**
      * @test
      */
-    public function passes_the_requested_entry_to_the_factory()
+    public function uses_the_provided_factory_arguments()
     {
         $provider = new FakeDefinitionProvider([
-            new FactoryCallDefinition('foo', new Reference('factory'), 'returnsRequestedId'),
+            (new FactoryCallDefinition('foo', new Reference('factory'), 'returnsRequestedId'))->setArguments('foobar'),
             new ObjectDefinition('factory', 'Assembly\Test\Container\Fixture\Factory'),
         ]);
 
         $container = new Container([], [$provider]);
 
         $this->assertTrue($container->has('foo'));
-        $this->assertSame('foo', $container->get('foo'));
+        $this->assertSame('foobar', $container->get('foo'));
     }
 }


### PR DESCRIPTION
Removed the previous test as I think it doesn't serve any purpose anymore.

---

Closes #7 
