### PR TITLE
Add branch alias

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,5 +29,10 @@
     },
     "require-dev": {
         "phpunit/phpunit": "~4.8"
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "0.1-dev"
+        }
     }
 }


### PR DESCRIPTION
So Assembly-next can be used with a version constraint until a version is tagged.
