### PR TITLE
Add ability to build ObjectDefinition with constructor arguments

### DIFF
--- a/src/ObjectDefinition.php
+++ b/src/ObjectDefinition.php
@@ -34,12 +34,14 @@ class ObjectDefinition extends NamedDefinition implements ObjectDefinitionInterf
     /**
      * @param string $identifier
      * @param string $className
+     * @param array  $constructorArguments
      */
-    public function __construct($identifier, $className)
+    public function __construct($identifier, $className, array $constructorArguments = [])
     {
         parent::__construct($identifier);
 
         $this->className = $className;
+        $this->constructorArguments = $constructorArguments;
     }
 
     /**


### PR DESCRIPTION
Unless the class being built is very simply you always need to pass constructor arguments which means you always have to do `(new ObjectDefinition($identifier, SomeClass::class))->setConstructorArguments($arguments)` – which is rather lengthy. Now you can just do `new ObjectDefinition($identifier, SomeClass::class, $arguments)`.

With the removal of identifiers this even brings it down to `new ObjectDefinition(SomeClass::class, $arguments)` which almost negates the need for an `object()` function considering how short it is.
