### PR TITLE
Separate into a new DefinitionResolver component the logic that resolves definitions

### DIFF
--- a/src/Container/Container.php
+++ b/src/Container/Container.php
@@ -2,14 +2,9 @@
 
 namespace Assembly\Container;
 
-use Assembly\ObjectDefinition;
 use Interop\Container\ContainerInterface;
-use Interop\Container\Definition\AliasDefinitionInterface;
 use Interop\Container\Definition\DefinitionInterface;
 use Interop\Container\Definition\DefinitionProviderInterface;
-use Interop\Container\Definition\FactoryCallDefinitionInterface;
-use Interop\Container\Definition\ParameterDefinitionInterface;
-use Interop\Container\Definition\ReferenceInterface;
 
 /**
  * Simple immutable container that can resolve standard definitions.
@@ -27,6 +22,11 @@ class Container implements ContainerInterface
     private $entries = [];
 
     /**
+     * @var DefinitionResolver
+     */
+    private $resolver;
+
+    /**
      * @param array $entries Container entries.
      */
     public function __construct(array $entries, array $providers = [])
@@ -35,6 +35,8 @@ class Container implements ContainerInterface
         foreach ($providers as $provider) {
             $this->addProvider($provider);
         }
+
+        $this->resolver = new DefinitionResolver($this);
     }
 
     public function get($id)
@@ -47,7 +49,7 @@ class Container implements ContainerInterface
             throw EntryNotFound::fromId($id);
         }
 
-        $this->entries[$id] = $this->resolveDefinition($this->definitions[$id]);
+        $this->entries[$id] = $this->resolver->resolve($this->definitions[$id]);
 
         return $this->entries[$id];
     }
@@ -65,76 +67,5 @@ class Container implements ContainerInterface
         foreach ($definitionProvider->getDefinitions() as $definition) {
             $this->definitions[$definition->getIdentifier()] = $definition;
         }
-    }
-
-    /**
-     * Resolve a definition and return the resulting value.
-     *
-     * @param DefinitionInterface $definition
-     * @return mixed
-     * @throws UnsupportedDefinition
-     * @throws EntryNotFound A dependency was not found.
-     */
-    private function resolveDefinition(DefinitionInterface $definition)
-    {
-        switch (true) {
-            case $definition instanceof ParameterDefinitionInterface:
-                return $definition->getValue();
-            case $definition instanceof ObjectDefinition:
-                $reflection = new \ReflectionClass($definition->getClassName());
-
-                // Create the instance
-                $constructorArguments = $definition->getConstructorArguments();
-                $constructorArguments = array_map([$this, 'resolveReference'], $constructorArguments);
-                $service = $reflection->newInstanceArgs($constructorArguments);
-
-                // Set properties
-                foreach ($definition->getPropertyAssignments() as $propertyAssignment) {
-                    $propertyName = $propertyAssignment->getPropertyName();
-                    $service->$propertyName = $this->resolveReference($propertyAssignment->getValue());
-                }
-
-                // Call methods
-                foreach ($definition->getMethodCalls() as $methodCall) {
-                    $methodArguments = $methodCall->getArguments();
-                    $methodArguments = array_map([$this, 'resolveReference'], $methodArguments);
-                    call_user_func_array([$service, $methodCall->getMethodName()], $methodArguments);
-                }
-
-                return $service;
-            case $definition instanceof AliasDefinitionInterface:
-                return $this->get($definition->getTarget());
-            case $definition instanceof FactoryCallDefinitionInterface:
-                $factory = $definition->getFactory();
-                $methodName = $definition->getMethodName();
-                $arguments = (array) $definition->getArguments();
-                $arguments = array_map([$this, 'resolveReference'], $arguments);
-
-                if (is_string($factory)) {
-                    return call_user_func_array($factory. '::' .$methodName, $arguments);
-                } elseif ($factory instanceof ReferenceInterface) {
-                    $factory = $this->get($factory->getTarget());
-                    return call_user_func_array([$factory, $methodName], $arguments);
-                }
-                throw new InvalidDefinition(sprintf('Definition "%s" does not return a valid factory'));
-            default:
-                throw UnsupportedDefinition::fromDefinition($definition);
-        }
-    }
-
-    /**
-     * Resolve a variable that can be a reference.
-     *
-     * @param ReferenceInterface|mixed $value
-     * @return mixed
-     * @throws EntryNotFound The dependency was not found.
-     */
-    private function resolveReference($value)
-    {
-        if ($value instanceof ReferenceInterface) {
-            $value = $this->get($value->getTarget());
-        }
-
-        return $value;
     }
 }

--- a/src/Container/DefinitionResolver.php
+++ b/src/Container/DefinitionResolver.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace Assembly\Container;
+
+use Assembly\ObjectDefinition;
+use Interop\Container\ContainerInterface;
+use Interop\Container\Definition\AliasDefinitionInterface;
+use Interop\Container\Definition\DefinitionInterface;
+use Interop\Container\Definition\FactoryCallDefinitionInterface;
+use Interop\Container\Definition\ParameterDefinitionInterface;
+use Interop\Container\Definition\ReferenceInterface;
+
+/**
+ * Resolves standard definitions.
+ */
+class DefinitionResolver
+{
+    /**
+     * @var ContainerInterface
+     */
+    private $container;
+
+    public function __construct(ContainerInterface $container)
+    {
+        $this->container = $container;
+    }
+
+    /**
+     * Resolve a definition and return the resulting value.
+     *
+     * @param DefinitionInterface $definition
+     *
+     * @return mixed
+     *
+     * @throws UnsupportedDefinition
+     * @throws InvalidDefinition
+     * @throws EntryNotFound A dependency was not found.
+     */
+    public function resolve(DefinitionInterface $definition)
+    {
+        switch (true) {
+            case $definition instanceof ParameterDefinitionInterface:
+                return $definition->getValue();
+
+            case $definition instanceof ObjectDefinition:
+                $reflection = new \ReflectionClass($definition->getClassName());
+
+                // Create the instance
+                $constructorArguments = $definition->getConstructorArguments();
+                $constructorArguments = array_map([$this, 'resolveReference'], $constructorArguments);
+                $service = $reflection->newInstanceArgs($constructorArguments);
+
+                // Set properties
+                foreach ($definition->getPropertyAssignments() as $propertyAssignment) {
+                    $propertyName = $propertyAssignment->getPropertyName();
+                    $service->$propertyName = $this->resolveReference($propertyAssignment->getValue());
+                }
+
+                // Call methods
+                foreach ($definition->getMethodCalls() as $methodCall) {
+                    $methodArguments = $methodCall->getArguments();
+                    $methodArguments = array_map([$this, 'resolveReference'], $methodArguments);
+                    call_user_func_array([$service, $methodCall->getMethodName()], $methodArguments);
+                }
+
+                return $service;
+
+            case $definition instanceof AliasDefinitionInterface:
+                return $this->container->get($definition->getTarget());
+
+            case $definition instanceof FactoryCallDefinitionInterface:
+                $factory = $definition->getFactory();
+                $methodName = $definition->getMethodName();
+                $arguments = (array) $definition->getArguments();
+                $arguments = array_map([$this, 'resolveReference'], $arguments);
+
+                if (is_string($factory)) {
+                    return call_user_func_array([$factory, $methodName], $arguments);
+                } elseif ($factory instanceof ReferenceInterface) {
+                    $factory = $this->container->get($factory->getTarget());
+                    return call_user_func_array([$factory, $methodName], $arguments);
+                }
+                throw new InvalidDefinition(sprintf('Definition "%s" does not return a valid factory'));
+
+            default:
+                throw UnsupportedDefinition::fromDefinition($definition);
+        }
+    }
+
+    /**
+     * Resolve a variable that can be a reference.
+     *
+     * @param ReferenceInterface|mixed $value
+     * @return mixed
+     * @throws EntryNotFound The dependency was not found.
+     */
+    private function resolveReference($value)
+    {
+        if ($value instanceof ReferenceInterface) {
+            $value = $this->container->get($value->getTarget());
+        }
+
+        return $value;
+    }
+}

--- a/tests/Container/DefinitionResolverTest.php
+++ b/tests/Container/DefinitionResolverTest.php
@@ -1,0 +1,133 @@
+<?php
+
+namespace Assembly\Test\Container;
+
+use Assembly\AliasDefinition;
+use Assembly\Container\Container;
+use Assembly\Container\DefinitionResolver;
+use Assembly\FactoryCallDefinition;
+use Assembly\ObjectDefinition;
+use Assembly\ParameterDefinition;
+use Assembly\Reference;
+use Assembly\Test\Container\Fixture\Class1;
+
+class DefinitionResolverTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @test
+     */
+    public function resolves_parameter_definitions()
+    {
+        $resolver = new DefinitionResolver(new Container([]));
+
+        $this->assertSame('bar', $resolver->resolve(new ParameterDefinition('foo', 'bar')));
+    }
+
+    /**
+     * @test
+     */
+    public function resolves_instance_definitions()
+    {
+        $definition = new ObjectDefinition('foo', 'Assembly\Test\Container\Fixture\Class1');
+        $definition->addPropertyAssignment('publicField', 'public field');
+        $definition->addConstructorArgument('constructor param1');
+        $definition->addConstructorArgument('constructor param2');
+        $definition->addMethodCall('setSomething', 'setter param1', 'setter param2');
+
+        $resolver = new DefinitionResolver(new Container([]));
+
+        /** @var Class1 $service */
+        $service = $resolver->resolve($definition);
+        $this->assertInstanceOf('Assembly\Test\Container\Fixture\Class1', $service);
+        $this->assertSame('public field', $service->publicField);
+        $this->assertSame('constructor param1', $service->constructorParam1);
+        $this->assertSame('constructor param2', $service->constructorParam2);
+        $this->assertSame('setter param1', $service->setterParam1);
+        $this->assertSame('setter param2', $service->setterParam2);
+    }
+
+    /**
+     * @test
+     */
+    public function resolves_references_in_instance_definitions()
+    {
+        $definition = new ObjectDefinition('foo', 'Assembly\Test\Container\Fixture\Class1');
+        $definition->addPropertyAssignment('publicField', new Reference('ref1'));
+        $definition->addConstructorArgument(new Reference('ref2'));
+        $definition->addConstructorArgument(new Reference('ref3'));
+        $definition->addMethodCall('setSomething', new Reference('ref4'), new Reference('ref5'));
+
+        $resolver = new DefinitionResolver(new Container([
+            'ref1' => 'public field',
+            'ref2' => 'constructor param1',
+            'ref3' => 'constructor param2',
+            'ref4' => 'setter param1',
+            'ref5' => 'setter param2',
+        ]));
+
+        /** @var Class1 $service */
+        $service = $resolver->resolve($definition);
+        $this->assertInstanceOf('Assembly\Test\Container\Fixture\Class1', $service);
+        $this->assertSame('public field', $service->publicField);
+        $this->assertSame('constructor param1', $service->constructorParam1);
+        $this->assertSame('constructor param2', $service->constructorParam2);
+        $this->assertSame('setter param1', $service->setterParam1);
+        $this->assertSame('setter param2', $service->setterParam2);
+    }
+
+    /**
+     * @test
+     */
+    public function resolves_alias_definitions()
+    {
+        $resolver = new DefinitionResolver(new Container([
+            'bar' => 'qux',
+        ]));
+
+        $this->assertSame('qux', $resolver->resolve(new AliasDefinition('foo', 'bar')));
+    }
+
+    /**
+     * @test
+     */
+    public function resolves_service_factory_definitions()
+    {
+        $provider = new FakeDefinitionProvider([
+            new ObjectDefinition('factory', 'Assembly\Test\Container\Fixture\Factory'),
+        ]);
+        $resolver = new DefinitionResolver(new Container([], [$provider]));
+
+        $result = $resolver->resolve(new FactoryCallDefinition('foo', new Reference('factory'), 'create'));
+
+        $this->assertSame('Hello', $result);
+    }
+
+    /**
+     * @test
+     */
+    public function resolves_static_factory_definitions()
+    {
+        $resolver = new DefinitionResolver(new Container([]));
+
+        $definition = new FactoryCallDefinition('foo', 'Assembly\Test\Container\Fixture\Factory', 'staticCreate');
+
+        $this->assertSame('Hello', $resolver->resolve($definition));
+    }
+
+    /**
+     * @test
+     */
+    public function passes_the_provided_factory_arguments()
+    {
+        $provider = new FakeDefinitionProvider([
+            new ObjectDefinition('factory', 'Assembly\Test\Container\Fixture\Factory'),
+            new ParameterDefinition('bar', 'bar'),
+        ]);
+        $resolver = new DefinitionResolver(new Container([], [$provider]));
+
+        $definition = (new FactoryCallDefinition('foo', new Reference('factory'), 'returnsParameters'))
+            ->setArguments('foo', new Reference('bar'));
+
+        $this->assertSame('foobar', $resolver->resolve($definition));
+    }
+}


### PR DESCRIPTION
The new `DefinitionResolver` can now be reused by other containers.
