### PR TITLE
[WIP] Adding compiler test suite to Assembly

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "~4.8",
-        "container-interop/definition-interop-compiler-test-suite": "dev-master"
+        "container-interop/definition-interop-tests": "dev-master"
     },
     "extra": {
         "branch-alias": {

--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,7 @@
     "type": "library",
     "description": "Implementation of interop container definitions",
     "license": "MIT",
+    "version": "dev-master",
     "authors": [
         {
             "name": "Matthieu Napoli",
@@ -28,7 +29,8 @@
         "container-interop/definition-interop": "~0.2.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.8"
+        "phpunit/phpunit": "~4.8",
+        "container-interop/definition-interop-compiler-test-suite": "dev-master"
     },
     "extra": {
         "branch-alias": {

--- a/tests/Container/DefinitionInteropCompatibilityTest.php
+++ b/tests/Container/DefinitionInteropCompatibilityTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Assembly\Test\Container;
+
+use Assembly\Container\Container;
+use Assembly\ObjectInitializer\MethodCall;
+use Assembly\ObjectInitializer\PropertyAssignment;
+use Assembly\Reference;
+use Interop\Container\ContainerInterface;
+use Interop\Container\Definition\DefinitionProviderInterface;
+use Interop\Container\Definition\Test\AbstractDefinitionCompatibilityTest;
+use Mouf\Picotainer\Picotainer;
+use TheCodingMachine\Yaco\Definition\AbstractDefinitionTest;
+
+class DefinitionInteropCompatibilityTest extends AbstractDefinitionCompatibilityTest
+{
+
+
+    /**
+     * Takes a definition provider in parameter and returns a container containing the entries.
+     *
+     * @param DefinitionProviderInterface $definitionProvider
+     * @return ContainerInterface
+     */
+    protected function getContainer(DefinitionProviderInterface $definitionProvider)
+    {
+        return new Container([], [ $definitionProvider ]);
+    }
+}

--- a/tests/Container/DefinitionInteropCompatibilityTest.php
+++ b/tests/Container/DefinitionInteropCompatibilityTest.php
@@ -3,14 +3,9 @@
 namespace Assembly\Test\Container;
 
 use Assembly\Container\Container;
-use Assembly\ObjectInitializer\MethodCall;
-use Assembly\ObjectInitializer\PropertyAssignment;
-use Assembly\Reference;
 use Interop\Container\ContainerInterface;
 use Interop\Container\Definition\DefinitionProviderInterface;
 use Interop\Container\Definition\Test\AbstractDefinitionCompatibilityTest;
-use Mouf\Picotainer\Picotainer;
-use TheCodingMachine\Yaco\Definition\AbstractDefinitionTest;
 
 class DefinitionInteropCompatibilityTest extends AbstractDefinitionCompatibilityTest
 {


### PR DESCRIPTION
I've added compiler test suite to Assembly to see how it goes.

So far, it goes pretty well. There is only one catch about how to handle exceptions regarding parameters passed. I might remove this test, but it probably means we should discuss about what is ok and what is not as a parameter.

For instance: is it ok to pass an object as a parameter? etc...

Failing test is here: https://github.com/container-interop/definition-interop-compiler-test-suite/blob/master/src/AbstractDefinitionCompatibilityTest.php#L49-L57

Also, I've had to add the "version" to `composer.json`. I don't like it, but since `container-interop/definition-interop-compiler-test-suite` require assembly, there is a cyclic dependency that can only be solved by specifying the version number of the root package to composer. An alternative would be to split Assembly in 2 packages: the classes implementing _definition-interop_ interface and the compiler. But that's getting a bit out of scope.
