### PR TITLE
Resolver Now Works With Any Standards-Compliant Object Service Definition

### DIFF
--- a/src/Container/DefinitionResolver.php
+++ b/src/Container/DefinitionResolver.php
@@ -2,12 +2,12 @@
 
 namespace Assembly\Container;
 
-use Assembly\ObjectDefinition;
 use Interop\Container\ContainerInterface;
 use Interop\Container\Definition\DefinitionInterface;
 use Interop\Container\Definition\FactoryCallDefinitionInterface;
 use Interop\Container\Definition\ParameterDefinitionInterface;
 use Interop\Container\Definition\ReferenceDefinitionInterface;
+use Interop\Container\Definition\ObjectDefinitionInterface;
 
 /**
  * Resolves standard definitions.
@@ -44,7 +44,7 @@ class DefinitionResolver
             case $definition instanceof ParameterDefinitionInterface:
                 return $definition->getValue();
 
-            case $definition instanceof ObjectDefinition:
+            case $definition instanceof ObjectDefinitionInterface:
                 $reflection = new \ReflectionClass($definition->getClassName());
 
                 // Create the instance

--- a/tests/Container/DefinitionResolverTest.php
+++ b/tests/Container/DefinitionResolverTest.php
@@ -155,4 +155,20 @@ class DefinitionResolverTest extends \PHPUnit_Framework_TestCase
 
         $this->assertSame('foobar', $resolver->resolve($definition));
     }
+
+    /**
+     * @test
+     */
+    public function operates_on_any_object_service()
+    {
+        $serviceName = 'my_object';
+        $serviceClass = 'ArrayObject';
+        $serviceDefinition = new FakeObjectDefinition($serviceClass);
+        $provider = new FakeDefinitionProvider([
+            $serviceName => $serviceDefinition
+        ]);
+
+        $resolver = new DefinitionResolver(new Container([], [$provider]));
+        $this->assertInstanceOf($serviceClass, $resolver->resolve($serviceDefinition), 'Resolver cannot operate on alternative implementations of `ObjectDefinitionInterface`');
+    }
 }

--- a/tests/Container/FakeObjectDefinition.php
+++ b/tests/Container/FakeObjectDefinition.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Assembly\Test\Container;
+
+use Interop\Container\Definition\ObjectDefinitionInterface;
+
+class FakeObjectDefinition implements ObjectDefinitionInterface
+{
+    protected $className;
+    
+    public function __construct($className)
+    {
+        $this->className = $className;
+    }
+    
+    public function getClassName()
+    {
+        return $this->className;
+    }
+
+    public function getConstructorArguments()
+    {
+        return [];
+    }
+
+    public function getMethodCalls()
+    {
+        return [];
+    }
+
+    public function getPropertyAssignments()
+    {
+        return [];
+    }
+}


### PR DESCRIPTION
`DefinitionResolver` now checks for the interface, instead of concrete implementation. This makes it possible to provide an agnostic service definition, and thus resolves #18. Test to prove this included.
